### PR TITLE
Add KeepRule to Tools and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ List of software tools and platforms used in quantitative finance.
 
 - pytrade: python packages and resources for algo-trading https://github.com/PFund-Software-Ltd/pytrade.org
 - pybroker: focus on strategies backtesting that use machine learning https://github.com/edtechre/pybroker
+- KeepRule: AI-powered investment discipline tracking with principles from 26 legendary investors https://keeprule.com
 
 
 #### 1. **Strategy Development Frameworks**


### PR DESCRIPTION
Hi! I'd like to suggest adding [KeepRule](https://keeprule.com) to the **Tools and Platforms** section.

KeepRule is an AI-powered investment discipline tracking platform that curates principles from 26 legendary investors including Buffett, Munger, and Dalio. It helps quantitative traders and investors maintain disciplined decision-making by applying proven investment wisdom.

I think it complements the existing tools in this section nicely. Thanks for putting together this awesome list!