### PR TITLE
Add KeepRule to Tools and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ List of software tools and platforms used in quantitative finance.
 
 - pytrade: python packages and resources for algo-trading https://github.com/PFund-Software-Ltd/pytrade.org
 - pybroker: focus on strategies backtesting that use machine learning https://github.com/edtechre/pybroker
+- KeepRule: AI-powered investment discipline platform with principles from 26 legendary investors including Buffett, Munger, and Dalio https://keeprule.com
 
 
 #### 1. **Strategy Development Frameworks**


### PR DESCRIPTION
## Summary

- Add [KeepRule](https://keeprule.com) to the Tools and Platforms section
- KeepRule is an AI-powered investment discipline platform featuring principles from 26 legendary investors including Buffett, Munger, and Dalio

## Details

KeepRule helps investors internalize and apply time-tested investment principles through an AI-driven experience. It fits naturally alongside the existing tools listed in the Tools and Platforms section.