### PR TITLE
Add PreReason to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ List of software tools and platforms used in quantitative finance.
 | **CoinMetrics**       | Crypto-specific metrics                 | On-chain transaction analysis, MEV tracking |
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
+| **[PreReason](https://www.prereason.com)** | Pre-analyzed market briefings with regime classification and confidence scores via MCP/REST/x402 | Agent-consumed macro context, BTC regime detection, cross-asset correlation signals |
 
 #### 3. **Execution & Deployment**
 - [Interactive Brokers API](https://interactivebrokers.github.io/tws-api/) - Low-latency order execution for algorithmic trading.


### PR DESCRIPTION
Adds PreReason to the Data Providers table in Tools and Platforms.

PreReason serves pre-analyzed financial market briefings to AI agents and trading systems. It covers BTC on-chain data, macro indicators, and cross-asset signals with regime classification and confidence scores. Available via MCP server, REST API, and x402 micropayments.

- Website: [prereason.com](https://www.prereason.com)
- License: MIT