### PR TITLE
Add CoinPaprika and DexPaprika to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ List of software tools and platforms used in quantitative finance.
 | **Yahoo Finance**     | Open-source financial data              | Basic equity/ETF research              |
 | **Bloomberg Terminal**| Institutional-grade market data         | High-frequency trading, ESG analytics  |
 | **CoinMetrics**       | Crypto-specific metrics                 | On-chain transaction analysis, MEV tracking |
+| **[CoinPaprika](https://api.coinpaprika.com)** | Free crypto market data (12K+ coins, 350+ exchanges) | Tickers, OHLCV, historical prices. No API key for free tier |
+| **[DexPaprika](https://api.dexpaprika.com)** | Free DEX data (34 chains, 30M+ pools, real-time streaming) | On-chain DEX analytics, pool data, token prices. No API key |
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
 


### PR DESCRIPTION
Adds two free crypto data providers to the Data Providers table:

- **CoinPaprika** — 12K+ coins, 350+ exchanges. Free, no API key. Use cases: tickers, OHLCV, historical prices.
- **DexPaprika** — 34 chains, 30M+ pools, real-time streaming. Free, no API key. Use cases: on-chain DEX analytics, pool data, token prices.

Both complement existing providers (Alpha Vantage, CoinMetrics) with free crypto/DEX market data.