### PR TITLE
docs: add Adanos to data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ List of software tools and platforms used in quantitative finance.
 | **CoinMetrics**       | Crypto-specific metrics                 | On-chain transaction analysis, MEV tracking |
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
+| **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |
 
 #### 3. **Execution & Deployment**
 - [Interactive Brokers API](https://interactivebrokers.github.io/tws-api/) - Low-latency order execution for algorithmic trading.


### PR DESCRIPTION
## Summary

Add Adanos to the `Data Providers` table in the README.

Adanos provides multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket, which fits the repository's focus on AI/ML-driven quantitative research and alternative data workflows.

## Why this fits

The existing `Data Providers` section already includes both traditional and alternative-data-oriented providers. Adanos is most relevant here as a sentiment and alternative-data source for:
- event-driven signal generation
- sentiment factor modeling
- alternative data research for US equities
