### PR TITLE
Add DeepAlpha - AI crypto trading bot with 70.9% accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Quantitative approaches to decentralized finance: MEV extraction, AMM liquidity 
 
 ## Tools and Platforms
 
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 70.9% walk-forward validated accuracy. XGBoost + LightGBM ensemble with 72 features. MIT license.
+
 List of software tools and platforms used in quantitative finance.
 
 - [pytrade](https://github.com/PFund-Software-Ltd/pytrade.org) - Python packages and resources for algo-trading.


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to this awesome list.

**DeepAlpha** is an open-source AI-powered crypto trading bot featuring:
- 70.9% walk-forward validated accuracy
- XGBoost + LightGBM ensemble with 72 engineered features
- Support for Bybit and Binance via CCXT
- MIT licensed
- Active development with 11+ model versions

## Checklist
- [x] Entry follows the existing format
- [x] Project is open source (MIT license)
- [x] Project is actively maintained
- [x] Description is concise and accurate
