### PR TITLE
Add 13F Insight to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ List of software tools and platforms used in quantitative finance.
 | **[DexPaprika](https://api.dexpaprika.com)** | Free DEX data (34 chains, 30M+ pools, real-time streaming) | On-chain DEX analytics, pool data, token prices. No API key |
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
+| **[13F Insight](https://13finsight.com)** | AI-powered 13F institutional holdings tracker with real-time filing alerts and hedge fund portfolio analysis | Institutional investor research, alpha discovery, smart money tracking |
 | **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |
 
 #### 3. **Execution & Deployment**


### PR DESCRIPTION
## What

Add [13F Insight](https://13finsight.com) to the **Data Providers** section (§2), positioned alongside StockAInsights — both focus on SEC institutional data.

## Why

13F Insight provides AI-powered tracking of institutional 13F holdings, real-time SEC filing alerts, and hedge fund portfolio analysis. For quant AI researchers, this is a high-signal alternative data source:

- **What moved**: Identify position changes from 5,000+ institutional filers each quarter
- **Timing signals**: Real-time alerts when major funds file (useful for event-driven strategies)
- **Hedge fund analysis**: Aggregate portfolio construction from top performers like Berkshire, Bridgewater, AQR

With the Q1 2026 13F filing window opening May 15, this is directly relevant for researchers studying institutional flow and smart money signals.

## Table row added

```
| **[13F Insight](https://13finsight.com)** | AI-powered 13F institutional holdings tracker with real-time filing alerts and hedge fund portfolio analysis | Institutional investor research, alpha discovery, smart money tracking |
```