### PR TITLE
Add DeepAlpha to Tools and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ List of software tools and platforms used in quantitative finance.
 - [pytrade](https://github.com/PFund-Software-Ltd/pytrade.org) - Python packages and resources for algo-trading.
 - [pybroker](https://github.com/edtechre/pybroker) - Algorithmic trading framework focused on strategies backtesting that use machine learning.
 - [KeepRule](https://keeprule.com) - AI-powered investment discipline platform with principles from 26 legendary investors including Buffett, Munger, and Dalio.
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI-powered crypto trading bot with 3-model ML ensemble (XGBoost, LightGBM, CatBoost), 12 exchanges via CCXT, grid trading, DCA with safety orders. Walk-forward validated.
 
 #### 1. **Strategy Development Frameworks**
 | **Tool**              | **Strength**                          | **Community Activity** | **Academic Adoption** | **Enterprise Use** |

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Quantitative approaches to decentralized finance: MEV extraction, AMM liquidity 
 
 ## Tools and Platforms
 
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 70.9% walk-forward validated accuracy. XGBoost + LightGBM ensemble with 72 features. MIT license.
+
 List of software tools and platforms used in quantitative finance.
 
 - [pytrade](https://github.com/PFund-Software-Ltd/pytrade.org) - Python packages and resources for algo-trading.


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Tools and Platforms section.

**DeepAlpha** is an open-source AI-powered crypto trading bot featuring:
- 3-model ML ensemble (XGBoost, LightGBM, CatBoost) with 70%+ walk-forward accuracy
- 12 exchanges supported via CCXT
- Grid trading, DCA with safety orders
- Walk-forward validation methodology
- Real-time dashboard and REST API

Fits well alongside pybroker and other strategy development tools.

Thank you for maintaining this awesome list!