### PR TITLE
Add oracle3 to LLM-Based Trading Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Multi-agent systems using large language models in specialized roles (analyst, t
 - [FinGPT](https://github.com/AI4Finance-Foundation/FinGPT) - Open-source financial LLM framework with data-centric design and LoRA fine-tuning; supports sentiment analysis, robo-advising, and algorithmic trading.
 - [FinRL](https://github.com/AI4Finance-Foundation/FinRL) - Financial reinforcement learning framework supporting A2C, DDPG, PPO, TD3, SAC agents; FinRL-X adds modular infrastructure for the LLM/agentic AI era.
 - [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) - Natural-language multi-agent finance research framework with 29 swarm presets (investment committee, quant desk, risk committee); 7 cross-market backtest engines (A-shares/US/Crypto/Futures/Forex/Options) plus a shared-capital CompositeEngine; 5-source auto-fallback data layer (tushare/okx/yfinance/akshare/ccxt); 17-tool MCP server for Claude Desktop; CLI + FastAPI + React frontend.
+- [oracle3](https://github.com/YichengYang-Ethan/oracle3) - Autonomous Python trading agent for Kalshi, Polymarket, and Solana DFlow using Wang Transform pricing (hierarchical MLE on 291k contracts, λ̂ = 0.183), Greeks, Kelly sizing, and eight constraint-based arbitrage strategies. Apache 2.0; methodology in companion SSRN working paper. (Author: @YichengYang-Ethan)
 
 ### Transformer Time-Series Foundation Models
 


### PR DESCRIPTION
**Affiliation disclosure**: I am the author of oracle3 (per CONTRIBUTING.md guidance).

Adding [oracle3](https://github.com/YichengYang-Ethan/oracle3) to the **LLM-Based Trading Agents** section.

oracle3 is an autonomous Python trading agent for prediction markets (Kalshi, Polymarket, Solana DFlow) backed by a research paper. The pricing engine applies the Wang Transform calibrated on 291,309 resolved contracts via hierarchical MLE (λ̂ = 0.183, p < 10⁻¹⁵, all covariate signs match theory). Includes Greeks, Kelly sizing, eight constraint-based arbitrage strategies, plus optional LLM agent integration for narrative-driven trades.

**Working paper**: [Pricing Prediction Markets: Risk Premiums, Incomplete Markets, and a Decomposition Framework](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338) (Yang, 2026, UIUC)

### Quality
- Apache 2.0 (open source)
- 633 tests; mypy + ruff + codespell CI
- v1.1.0 released 2026-05-07
- Stars: 170+
- Documentation: full [docs site](https://yichengyang-ethan.github.io/oracle3)

Followed CONTRIBUTING format: `- [Name](url) - Brief description.` ending with period. Single project per PR.