### PR TITLE
Add AI Stock Monitor to Tools and Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ List of software tools and platforms used in quantitative finance.
 - [pytrade](https://github.com/PFund-Software-Ltd/pytrade.org) - Python packages and resources for algo-trading.
 - [pybroker](https://github.com/edtechre/pybroker) - Algorithmic trading framework focused on strategies backtesting that use machine learning.
 - [KeepRule](https://keeprule.com) - AI-powered investment discipline platform with principles from 26 legendary investors including Buffett, Munger, and Dalio.
+- [AI Stock Monitor — Best AI Stocks](https://aistockmonitor.io/picks/best-ai-stocks) - Screener for AI-exposed US stocks. Each ticker tagged with a verdict computed from PE percentile, IV rank, and the share of revenue tied to AI demand. Universe is hand-curated and refreshed each earnings season.
 
 #### 1. **Strategy Development Frameworks**
 | **Tool**              | **Strength**                          | **Community Activity** | **Academic Adoption** | **Enterprise Use** |


### PR DESCRIPTION
Adding a free web-based screener I built (aistockmonitor.io/picks/best-ai-stocks) under the   
  Tools and Platforms section.                                                                  
                                                                                                
The angle: most AI-stock listicles cover the same 7 names. This one is a hand-curated universe
of ~34 tickers across 9 supply-chain layers (fab equipment, chips, memory, networking,       
  hyperscalers, software, etc.), with each ticker getting a rule-based tag based on PE   
  percentile, IV rank, and how much of its revenue is actually AI-tied. Refreshed each earnings 
  season.                                                                                      
                                                                                              
  Free, no signup, server-side rendered. Source code for the verdict engine is open if anyone
  wants to see how the categories are computed.                                                 
                                               
  Let me know if you'd like the description tightened. 