### PR TITLE
Add Sharpe to data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ List of software tools and platforms used in quantitative finance.
 | **CoinMetrics**       | Crypto-specific metrics                 | On-chain transaction analysis, MEV tracking |
 | **[CoinPaprika](https://api.coinpaprika.com)** | Free crypto market data (12K+ coins, 350+ exchanges) | Tickers, OHLCV, historical prices. No API key for free tier |
 | **[DexPaprika](https://api.dexpaprika.com)** | Free DEX data (34 chains, 30M+ pools, real-time streaming) | On-chain DEX analytics, pool data, token prices. No API key |
+| **[Sharpe](https://www.sharpe.ai/docs/free-api)** | Free crypto market intelligence API covering funding rates, options, arbitrage, narratives, exchange listings, and news | Crypto market-regime research, derivatives positioning, and agent-ready data collection. Public endpoints work without signup |
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
 | **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |


### PR DESCRIPTION
Adds Sharpe to the Tools and Platforms data providers table.

I read the contribution criteria and placed this in Data Providers because the linked resource is a free/open crypto market intelligence API rather than a trading bot, alert service, or generic AI wrapper. The row focuses on research use cases: funding rates, options, arbitrage, narratives, exchange listings, news, derivatives positioning, and agent-ready data collection.

Website URL: https://www.sharpe.ai/docs/free-api
Validation: `git diff --check` passes.
Linear: SHA-182

Disclosure: I work on Sharpe.