### PR TITLE
Add FilingFirehose (SEC EDGAR + AI integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A curated list of awesome resources for quantitative investment and trading stra
 <br>
 
 ## Contents
+- [FilingFirehose](https://filingfirehose.com) - SEC EDGAR JSON API with body-text-classified 8-Ks, activist 13D tagging, ATM detection. Hosted MCP server + ChatGPT GPT for AI workflows. Free public tier, paid $29-$299/mo.
 
 - [Introduction](#introduction)
 - [Design Approach](#design-approach)


### PR DESCRIPTION
Adds FilingFirehose, an SEC EDGAR JSON API I built that body-text-classifies every 8-K and flags items the filer didn't report (7.3% of recent Item 8.01 filings have buried 1.05/5.02/etc events). Tags 21+ activist filers on every Schedule 13D/G; detects ATM offerings on S-3/424B5.

For systematic traders: free public tier (no auth, last 72h), paid tier from $29/mo for full historical archive + webhooks. Available as REST API, MCP server (Claude Desktop / Cursor / Windsurf), Python SDK, GitHub Action, and ChatGPT GPT.

- Site: https://filingfirehose.com
- Research: https://filingfirehose.com/research/buried-events
- Free public API: https://filingfirehose.com/v1/public/8k?suspected_buried_only=true