### PR TITLE
feat: add TWZRD Agent Intel to On-Chain / DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Quantitative approaches to decentralized finance: MEV extraction, AMM liquidity 
 - [Flashbots rbuilder](https://github.com/flashbots/rbuilder) - Open-source, high-performance Ethereum MEV-Boost block builder written in Rust; supports multiple building algorithms and backtesting.
 - [DefiLlama](https://defillama.com/) - Open-source DeFi analytics dashboard tracking TVL, yields, fees, and volumes across thousands of protocols; provides free API via [defillama-sdk](https://github.com/DefiLlama/defillama-sdk).
 - [ultimate-defi-research-base](https://github.com/OffcierCia/ultimate-defi-research-base) - Curated collection of DeFi and blockchain research covering MEV, AMM design, yield optimization, and on-chain analytics.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for Solana AI agent wallets; verify agent identity before x402 USDC micropayments. Exposes `score_agent` and `preflight_check` tools (free) plus a signed `get_trust_receipt` (HTTP 402 paid). Zero-install: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`.
 
 
 ## Tools and Platforms


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the On-Chain / DeFi Quantitative Strategies section.

TWZRD Agent Intel is a trust-scoring MCP server for Solana AI agent wallets. It provides identity verification for agent-to-agent x402 USDC micropayments on Solana — a new infrastructure layer emerging in DeFi where autonomous AI agents need to pay each other programmatically.

**Disclosure:** I built this.

### Why it fits this section

- Solana on-chain infrastructure for AI agent verification
- Directly relevant to DeFi quant strategies that interact with AI agents
- Free open API via MCP, no sales call required
- Live production service with real on-chain verification

### MCP tools

| Tool | Cost | Description |
|------|------|-------------|
| `score_agent(wallet)` | Free | Trust score 0–100 based on on-chain signals |
| `preflight_check(wallet)` | Free | Score + stake + wallet age + activity |
| `get_trust_receipt(wallet)` | HTTP 402 USDC | Signed, verifiable trust receipt |

### Config

```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Placement: end of the On-Chain / DeFi Quantitative Strategies section, after `ultimate-defi-research-base`.