### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ List of software tools and platforms used in quantitative finance.
 | **FinancialData.Net** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
 | **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |
+| **[The Stall](https://github.com/thebrierfox/the-stall)** | x402 pay-per-call MCP server — 183 AI data tools for quant finance: US/intl stocks, equity fundamentals, macro indicators, options chains, earnings, insider trades, hedge fund holdings, crypto/DeFi analytics. No API keys required; USDC micropayments on Base | Quantitative research data layer, agent-native finance pipelines, pay-as-you-go market data access |
 
 #### 3. **Execution & Deployment**
 - [Interactive Brokers API](https://interactivebrokers.github.io/tws-api/) - Low-latency order execution for algorithmic trading.


### PR DESCRIPTION
## Summary

[The Stall](https://github.com/thebrierfox/the-stall) is an x402 pay-per-call MCP server providing 209 AI data tools purpose-built for quantitative finance research and agent-native pipelines.

**Why it fits awesome-quant-ai:**
- **Equity fundamentals**: US + international stocks, earnings, insider trades, hedge fund 13F holdings
- **Macro indicators**: interest rates, CPI, GDP, PMI, yield curves
- **Options data**: full chains, IV surfaces, Greeks
- **Crypto / DeFi analytics**: on-chain data, DEX pools, token flows
- **Social signals**: Reddit, X/Twitter sentiment for alternative data

**Key differentiators:**
- No API keys required — agent-native access via MCP protocol
- USDC micropayments on Base via x402 standard — pay only for what you call
- 209 live capabilities, actively maintained
- Live endpoint: https://the-stall.intuitek.ai

git: a8ccfc4 | version: v4.63.1 | caps: 209

Added to the **Data Providers** subsection under Tools and Platforms, consistent with existing entries like CoinPaprika, DexPaprika, and Adanos.