### PR TITLE
Add BDE Score to Data Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ List of software tools and platforms used in quantitative finance.
 | **[DexPaprika](https://api.dexpaprika.com)** | Free DEX data (34 chains, 30M+ pools, real-time streaming) | On-chain DEX analytics, pool data, token prices. No API key |
 | **[FinancialData.Net](https://financialdata.net/)** | Stock market and financial data         | Financial analysis, data integration   |
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
+| **[BDE Score](https://github.com/hbhqq9/bde-score)** | AI-powered multi-market stock scoring (US/HK/A-share, 73 stocks). BDE transparency framework | Multi-market equity analysis, scoring, EU AI Act Art.50 compliant |
 | **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |
 
 #### 3. **Execution & Deployment**


### PR DESCRIPTION
Adding BDE Score to the Data Providers section.

BDE Score is an AI-powered multi-market stock analysis tool providing transparent scoring across 73 stocks (US/HK/A-share). It offers:
- REST API + Python SDK for automated stock analysis
- Technical + fundamental + sentiment analysis combined into a single score
- EU AI Act Art.50 compliant transparency
- Multi-market coverage (US, HK, A-share)

GitHub: https://github.com/hbhqq9/bde-score