### PR TITLE
Add AgentServices — x402-paid crypto/market data APIs with MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ List of software tools and platforms used in quantitative finance.
 | **[StockAInsights](https://stockainsights.com)** | Institutional-grade AI-extracted SEC financial statements (not XBRL) | Fundamental analysis, backtesting, screening |
 | **[Adanos](https://adanos.org)** | Multi-source market sentiment data for US stocks across Reddit, X, finance news, and Polymarket | Alternative data research, event-driven signal generation, sentiment factor modeling |
 | **[stock-analysis](https://github.com/AdvancingTitans/stock-analysis)** | Evidence-driven A/HK/US stock and fund recap CLI that emits JSON Evidence Packs | Multi-source public-data fallback for agent workflows, daily reports, and audit-ready market notes |
+| **[AgentServices](https://agentservices.to)** | 54 services, 97 paths, 41 x402-paid endpoints for crypto/market data with MCP integration | Agent-native data access with on-chain USDC payment settlement on Base |
 
 #### 3. **Execution & Deployment**
 - [Interactive Brokers API](https://interactivebrokers.github.io/tws-api/) - Low-latency order execution for algorithmic trading.


### PR DESCRIPTION
## What

Added **[AgentServices](https://agentservices.to)** to the **Data Providers** table in the Tools and Platforms section.

## Why

AgentServices is a production API platform providing crypto and market data with **41 x402-paid endpoints** across 54 services. It is specifically designed for **AI agent consumption** with:

- **37 MCP tools** (Model Context Protocol) — agents can discover and call endpoints natively
- **x402 payment protocol** — on-chain USDC micropayments on Base (no API keys, no signup)
- **97 API paths** covering FX rates, token prices, onchain analytics, market intelligence

This positions it alongside existing crypto data providers like CoinPaprika, DexPaprika, and CoinMetrics — with the differentiator of being agent-native (MCP + x402).

## Details

- Homepage: https://agentservices.to
- API: https://api.agentservices.to
- MCP server: https://api.agentservices.to/mcp (protocol 2026-07-28)
- x402 well-known: https://api.agentservices.to/.well-known/x402
- On official MCP Registry: `to.agentservices/agentservices` (v5.3.0)
- Verified healthy: HTTP 200 on all endpoints

Happy to adjust the table entry format or description to match house style.